### PR TITLE
Maintain state between renders (shallow render)

### DIFF
--- a/src/QueryCollection.js
+++ b/src/QueryCollection.js
@@ -1,4 +1,3 @@
-import ReactTestUtils from'react-addons-test-utils';
 import common from './common';
 
 
@@ -48,7 +47,6 @@ export default function(match, selector, init){
 
       this._isQueryCollection = true
       this.length = elements.length;
-      this.renderer = ReactTestUtils.createRenderer()
     }
 
     $.fn.init.prototype = $.fn

--- a/src/QueryCollection.js
+++ b/src/QueryCollection.js
@@ -1,3 +1,4 @@
+import ReactTestUtils from'react-addons-test-utils';
 import common from './common';
 
 
@@ -47,6 +48,7 @@ export default function(match, selector, init){
 
       this._isQueryCollection = true
       this.length = elements.length;
+      this.renderer = ReactTestUtils.createRenderer()
     }
 
     $.fn.init.prototype = $.fn

--- a/src/element.js
+++ b/src/element.js
@@ -1,6 +1,5 @@
 import React, { isValidElement, cloneElement } from 'react';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from'react-addons-test-utils';
 import createQueryCollection from './QueryCollection';
 import iQuery from './instance'
 import * as utils from './utils';
@@ -47,9 +46,8 @@ Object.assign(eQuery.fn, {
     if (isDomElement)
       return eQuery(element)
 
-    let renderer = ReactTestUtils.createRenderer()
-    renderer.render(element)
-    return eQuery(renderer.getRenderOutput());
+    this.renderer.render(element)
+    return eQuery(this.renderer.getRenderOutput());
   },
 
   children(selector) {

--- a/src/element.js
+++ b/src/element.js
@@ -1,5 +1,6 @@
 import React, { isValidElement, cloneElement } from 'react';
 import ReactDOM from 'react-dom';
+import ReactTestUtils from'react-addons-test-utils';
 import createQueryCollection from './QueryCollection';
 import iQuery from './instance'
 import * as utils from './utils';
@@ -45,6 +46,9 @@ Object.assign(eQuery.fn, {
 
     if (isDomElement)
       return eQuery(element)
+
+    if(!this.renderer)
+      this.renderer = ReactTestUtils.createRenderer()
 
     this.renderer.render(element)
     return eQuery(this.renderer.getRenderOutput());

--- a/test/shallow.js
+++ b/test/shallow.js
@@ -20,6 +20,24 @@ describe('Shallow rendering', ()=> {
       )
     }
   }
+  let counterRef
+  let Counter = class extends React.Component {
+    constructor(){
+      super()
+      this.state = {count:0}
+      counterRef = this;
+    }
+
+    increment(){
+      this.setState({count:this.state.count + 1});
+    }
+
+    render(){
+      return (
+        <span className={this.state.count}>{this.state.count}</span>
+      )
+    }
+  }
 
   it('create element collection', ()=>{
     let instance = $(<div/>)
@@ -65,6 +83,14 @@ describe('Shallow rendering', ()=> {
       )
 
     instance.children().length.should.equal(3)
+  })
+
+  it('should maintain state between renders', ()=>{
+    let counter = $(<Counter/>)
+
+    counter.shallowRender().context.props.className.should.equal(0)
+    counterRef.increment()
+    counter.shallowRender().context.props.className.should.equal(1)
   })
 
   describe('querying', ()=> {


### PR DESCRIPTION
At present, invoking `shallowRender()` causes fresh state to be generated (`getInitialState()` is invoked) making it impossible to test any state changes.
