### PR TITLE
Maintain state between renders (full render)

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -27,12 +27,14 @@ Object.assign(eQuery.fn, {
     if (intoDocument)
       document.body.appendChild(mount)
 
-    let instance = ReactDOM.render(element, mount);
+    if (!this.instance) {
+      this.instance = ReactDOM.render(element, mount);
 
-    if (instance === null)
-      instance = ReactDOM.render(utils.wrapStateless(element), mount)
+      if (this.instance === null)
+        this.instance = ReactDOM.render(utils.wrapStateless(element), mount)
+    }
 
-    return iQuery(instance, utils.getInternalInstance(instance), mount);
+    return iQuery(this.instance, utils.getInternalInstance(this.instance), mount);
   },
 
   shallowRender(props) {

--- a/test/dom.js
+++ b/test/dom.js
@@ -36,6 +36,25 @@ describe('DOM rendering', ()=> {
     }
   }
 
+  let counterRef
+  let Counter = class extends React.Component {
+    constructor(){
+      super()
+      this.state = {count:0}
+      counterRef = this;
+    }
+
+    increment(){
+      this.setState({count:this.state.count + 1});
+    }
+
+    render(){
+      return (
+        <span className={this.state.count}>{this.state.count}</span>
+      )
+    }
+  }
+
   it('should wrap existing mounted component', ()=> {
     let mount = document.createElement('div')
       , instance = render(<div className='test'/>, mount)
@@ -86,6 +105,14 @@ describe('DOM rendering', ()=> {
     let instance = $(<Component className='test'/>)
 
     instance.get()[0].should.equal(instance[0])
+  })
+
+  it('should maintain state between renders', ()=>{
+    let counter = $(<Counter/>)
+
+    counter.render().dom().textContent.should.equal('0')
+    counterRef.increment()
+    counter.render().dom().textContent.should.equal('1')
   })
 //
 //   it('should set props', ()=> {


### PR DESCRIPTION
At present, invoking `render()` causes fresh state to be generated (`getInitialState()` is invoked) making it harder for developers to test state changes &mdash; they must memoize invocations to `render()`, which never needed to be called more than once since React automatically re-renders as the props and/or state change.