### PR TITLE
State synchronization fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "bill": "^1.3.2",
+    "deep-equal": "^1.0.1",
     "dom-helpers": "^2.4.0",
     "lodash": "^3.10.1",
     "react-addons-test-utils": "^0.14.0-rc1"

--- a/src/QueryCollection.js
+++ b/src/QueryCollection.js
@@ -1,3 +1,4 @@
+import ReactTestUtils from'react-addons-test-utils';
 import common from './common';
 
 
@@ -47,6 +48,7 @@ export default function(match, selector, init){
 
       this._isQueryCollection = true
       this.length = elements.length;
+      this.renderer = ReactTestUtils.createRenderer()
     }
 
     $.fn.init.prototype = $.fn

--- a/src/element.js
+++ b/src/element.js
@@ -2,6 +2,7 @@ import React, { isValidElement, cloneElement } from 'react';
 import ReactDOM from 'react-dom';
 import createQueryCollection from './QueryCollection';
 import iQuery from './instance'
+import syncReact from './syncReact';
 import * as utils from './utils';
 import { selector } from 'bill';
 
@@ -67,5 +68,7 @@ Object.assign(eQuery.fn, {
   }
 
 })
+
+eQuery.syncReact = syncReact;
 
 export default eQuery;

--- a/src/element.js
+++ b/src/element.js
@@ -1,6 +1,5 @@
 import React, { isValidElement, cloneElement } from 'react';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from'react-addons-test-utils';
 import createQueryCollection from './QueryCollection';
 import iQuery from './instance'
 import * as utils from './utils';
@@ -47,9 +46,8 @@ Object.assign(eQuery.fn, {
     if (isDomElement)
       return eQuery(element)
 
-    let renderer = ReactTestUtils.createRenderer()
-    renderer.render(element)
-    return eQuery(renderer.getRenderOutput());
+    this.renderer.render(element)
+    return eQuery(this.renderer.getRenderOutput());
   },
 
   children(selector) {

--- a/src/syncReact.js
+++ b/src/syncReact.js
@@ -1,0 +1,21 @@
+import synchronizedComponent from './synchronizedComponent';
+
+export default function syncReact(React) {
+	return {
+		Component: React.Component,
+		createClass: React.createClass.bind(React),
+		createElement: function(type, props, children) {
+			if((typeof(type) == 'function') && type.prototype.render) {
+				type = synchronizedComponent(type);
+			}
+
+			return React.createElement(type, props, children);
+		},
+		cloneElement: React.cloneElement.bind(React),
+		createFactory: React.createFactory.bind(React),
+		isValidElement: React.isValidElement.bind(React),
+		DOM: React.DOM,
+		PropTypes: React.PropTypes,
+		Children: React.Children
+	}
+}

--- a/src/synchronizedComponent.js
+++ b/src/synchronizedComponent.js
@@ -1,0 +1,30 @@
+import deepEqual from 'deep-equal';
+
+export default function synchronizedComponent(Component) {
+	let instances = [];
+
+	return class SynchronizedComponent extends Component {
+		constructor() {
+			super();
+
+			if(instances.length > 0) {
+				let primaryComponent = instances[0];
+				this.state = primaryComponent.state;
+			}
+
+			instances.push(this);
+		}
+
+		componentDidUpdate(oldProps, oldState) {
+			if(Component.prototype.componentDidUpdate) {
+				super();
+			}
+
+			for(let component of instances) {
+				if((component != this) && !deepEqual(this.state, component.state)) {
+					component.setState(this.state);
+				}
+			}
+		}
+	}
+}

--- a/test/Counter.js
+++ b/test/Counter.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const Counter = class extends React.Component {
+	constructor(){
+		super()
+		this.state = {count:0}
+		Counter.ref = this;
+	}
+
+	increment(){
+		this.setState({count:this.state.count + 1});
+	}
+
+	render(){
+		return (
+			<span className={this.state.count}>{this.state.count}</span>
+		)
+	}
+}
+
+export default Counter;

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,8 @@
-import React from 'react';
 import { unmountComponentAtNode, render } from 'react-dom';
 import $ from '../src/element';
+import _React from 'react';
+const React = $.syncReact(_React);
+import Counter from './Counter';
 
 describe('common utils', ()=> {
   let Stateless = props => <div onClick={props.onClick}>{props.children}</div>
@@ -69,5 +71,47 @@ describe('common utils', ()=> {
 
     instance.length.should.equal(1)
     instance[0].type.should.equal('div')
+  })
+
+  describe('state synchronization between the shallow and deep rendered components', ()=>{
+    it('should stay sychronized when the state is initially changed in the shallow rendered component', ()=>{
+      let counter = $(<Counter/>)
+      counter.shallowRender()
+      let counterRef = Counter.ref
+
+      counter.shallowRender().context.props.className.should.equal(0)
+      counter.render().dom().textContent.should.equal('0')
+      counterRef.increment()
+      counter.shallowRender().context.props.className.should.equal(1)
+      counter.render().dom().textContent.should.equal('1')
+    })
+
+    it('should stay sychronized when the state is initially changed in the deep rendered component', ()=>{
+      let counter = $(<Counter/>)
+      counter.render()
+      let counterRef = Counter.ref
+
+      counter.shallowRender().context.props.className.should.equal(0)
+      counter.render().dom().textContent.should.equal('0')
+      counterRef.increment()
+      counter.shallowRender().context.props.className.should.equal(1)
+      counter.render().dom().textContent.should.equal('1')
+    })
+
+    it('should immediately synchronize the state of the shallow rendered component if state is already available', function() {
+      let counter = $(<Counter/>)
+
+      counter.render()
+      Counter.ref.increment()
+      counter.shallowRender().context.props.className.should.equal(1)
+    })
+
+    it('should immediately synchronize the state of the deep rendered component if state is already available', function() {
+      let counter = $(<Counter/>)
+
+      counter.shallowRender()
+      Counter.ref.increment()
+      counter.render().dom().textContent.should.equal('1')
+    })
   })
 })

--- a/test/dom.js
+++ b/test/dom.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { unmountComponentAtNode, render } from 'react-dom';
 import $ from '../src/element';
 import * as utils from '../src/utils';
+import Counter from './Counter';
 
 describe('DOM rendering', ()=> {
   let Stateless = props => <div onClick={props.onClick}>{props.children}</div>
@@ -32,25 +33,6 @@ describe('DOM rendering', ()=> {
             <List onClick={this.props.onClick}/>
           </div>
         </div>
-      )
-    }
-  }
-
-  let counterRef
-  let Counter = class extends React.Component {
-    constructor(){
-      super()
-      this.state = {count:0}
-      counterRef = this;
-    }
-
-    increment(){
-      this.setState({count:this.state.count + 1});
-    }
-
-    render(){
-      return (
-        <span className={this.state.count}>{this.state.count}</span>
       )
     }
   }
@@ -111,7 +93,7 @@ describe('DOM rendering', ()=> {
     let counter = $(<Counter/>)
 
     counter.render().dom().textContent.should.equal('0')
-    counterRef.increment()
+    Counter.ref.increment()
     counter.render().dom().textContent.should.equal('1')
   })
 //

--- a/test/shallow.js
+++ b/test/shallow.js
@@ -1,6 +1,6 @@
 import React, { cloneElement } from 'react';
 import $ from '../src/element';
-
+import Counter from './Counter';
 
 describe('Shallow rendering', ()=> {
   let Stateless = props => <div onClick={props.onClick}>{props.children}</div>
@@ -17,24 +17,6 @@ describe('Shallow rendering', ()=> {
             <li>hi 3</li>
           </ul>
         </div>
-      )
-    }
-  }
-  let counterRef
-  let Counter = class extends React.Component {
-    constructor(){
-      super()
-      this.state = {count:0}
-      counterRef = this;
-    }
-
-    increment(){
-      this.setState({count:this.state.count + 1});
-    }
-
-    render(){
-      return (
-        <span className={this.state.count}>{this.state.count}</span>
       )
     }
   }
@@ -89,7 +71,7 @@ describe('Shallow rendering', ()=> {
     let counter = $(<Counter/>)
 
     counter.shallowRender().context.props.className.should.equal(0)
-    counterRef.increment()
+    Counter.ref.increment()
     counter.shallowRender().context.props.className.should.equal(1)
   })
 

--- a/test/shallow.js
+++ b/test/shallow.js
@@ -20,6 +20,24 @@ describe('Shallow rendering', ()=> {
       )
     }
   }
+  let counterRef
+  let Counter = class extends React.Component {
+    constructor(){
+      super()
+      this.state = {count:0}
+      counterRef = this;
+    }
+
+    increment(){
+      this.setState({count:this.state.count + 1});
+    }
+
+    render(){
+      return (
+        <span className={this.state.count}>{this.state.count}</span>
+      )
+    }
+  }
 
   it('create element collection', ()=>{
     let instance = $(<div/>)
@@ -65,6 +83,14 @@ describe('Shallow rendering', ()=> {
       )
 
     instance.children().length.should.equal(3)
+  })
+
+  it('should maintain state between renders', ()=>{
+    let counter = $(<Counter/>)
+
+    counter.shallowRender().context.props.className.should.equal(0)
+    counterRef.increment()
+    counter.shallowRender().context.props.className.should.equal(1)
   })
 
   describe('querying', ()=> {


### PR DESCRIPTION
This pull-request has a soft-dependency on #4 and #5. Whereas those pull-requests prevent `render()` and `shallowRender()` from continually creating new state, this pull-request causes the state produced by `render()` and `shallowRender()` to be synchronized, causing it to seem like there actually is only one render state in-play.

It allows tests that use the rendered DOM to perform behaviour changes, to subsequently use a shallow render to confirm those changes (or vice versa), for example:

```jsx
it('updates the footer information when the completed filter is clicked', function() {
  // given
  let todoApp = $(<TodoApp model={model} router={router}/>);

  // when
  todoApp.render().find('.completed').trigger('click');

  // then
  expect(todoApp.shallowRender()[0], 'to contain',
    <TodoFooter nowShowing="completed"/>
  );
});
```

At present, this pull-request requires the test author to load a modified version of `React` as follows:

```es6
import $ from 'teaspoon';
import _React from 'react';
const React = $.syncReact(_React);
```

My knowledge of React is quite poor, but in theory I believe it should be possible to hide this from the end-developer, and instead have _teaspoon_ automatically re-create the instantiated React components it receives, but where it uses `synchronizedComponent()` underneath the hood, so that tests automatically create synchronized versions of those components.

I'm encouraged to believe this may be possible since I can add the following snippet of code to `$.fn.init()` within `QueryCollection` without breaking any tests:

```js
if(element instanceof React.Component) {
  console.log('>>> CLONED');
  element = React.cloneElement(element);
}
```

This code is causing a completely new React component, with identical children and props to be created. If you could additionally swap the type with a synchronized version, then these details could be completely hidden from the developer.
