### PR TITLE
Add a node() convenience method

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -97,9 +97,7 @@ export default function($){
     },
 
     node() {
-      if (this.length !== 1) throw new Error('There were: ' + this.length + ' items not 1 ');
-
-      return this[0];
+      return this.single()[0]
     }
   })
 }

--- a/src/common.js
+++ b/src/common.js
@@ -96,7 +96,7 @@ export default function($){
         : this.only()
     },
 
-    node() {
+    unwrap() {
       return this.single()[0]
     }
   })

--- a/src/common.js
+++ b/src/common.js
@@ -94,6 +94,12 @@ export default function($){
       return selector
         ? this.find(selector).only()
         : this.only()
+    },
+
+    node() {
+      if (this.length !== 1) throw new Error('There were: ' + this.length + ' items not 1 ');
+
+      return this[0];
     }
   })
 }

--- a/test/common.js
+++ b/test/common.js
@@ -74,6 +74,6 @@ describe('common utils', ()=> {
   it('should allow the first node to retrieved', ()=>{
     let instance = $(<Stateless name='hi'/>).shallowRender()
 
-    instance.node().type.should.equal('div')
+    instance.unwrap().type.should.equal('div')
   })
 })

--- a/test/common.js
+++ b/test/common.js
@@ -70,4 +70,17 @@ describe('common utils', ()=> {
     instance.length.should.equal(1)
     instance[0].type.should.equal('div')
   })
+
+  it('should allow the first node to retrieved', ()=>{
+    let instance = $(<Stateless name='hi'/>).shallowRender()
+
+    instance.node().type.should.equal('div')
+  })
+
+  // TODO: this test can most neatly be written using an assertion library like chai or expectations
+  xit('should error if there are no nodes to be retrieved', ()=>{
+    let instance = $(<Stateless name='hi'/>).shallowRender().filter('NoSuchElem')
+
+    expect(()=>instance.node()).to.throw(Error);
+  })
 })

--- a/test/common.js
+++ b/test/common.js
@@ -76,11 +76,4 @@ describe('common utils', ()=> {
 
     instance.node().type.should.equal('div')
   })
-
-  // TODO: this test can most neatly be written using an assertion library like chai or expectations
-  xit('should error if there are no nodes to be retrieved', ()=>{
-    let instance = $(<Stateless name='hi'/>).shallowRender().filter('NoSuchElem')
-
-    expect(()=>instance.node()).to.throw(Error);
-  })
 })


### PR DESCRIPTION
This allows tests using `shallowRender()` to more easily access the rendered output.
