### PR TITLE
FIXED: README.md code sample in "'ref' style querying" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,7 @@ component's "real" props. In this example lets use `_testID`.
 ```js
 let Greeting = props => <div>hello <strong _testID='name'>{props.name}</strong></div>;
 
-$(<Greeting />)
-  .props({ name: 'Betty' })
+$(<Greeting name='Betty' />)
   .render()
   .find('[_testID=name]')
   .text()

--- a/README.md
+++ b/README.md
@@ -253,8 +253,9 @@ component's "real" props. In this example lets use `_testID`.
 ```js
 let Greeting = props => <div>hello <strong _testID='name'>{props.name}</strong></div>;
 
-$(Greeting).render()
-  .prop({ name: 'Betty' })
+$(<Greeting />)
+  .props({ name: 'Betty' })
+  .render()
   .find('[_testID=name]')
   .text()
   .should.equal('Betty')


### PR DESCRIPTION
Running the current example:

```
let Greeting = props => <div>hello <strong _testID='name'>{props.name}</strong></div>;

$(Greeting).render()
  .prop({ name: 'Betty' })
  .find('[_testID=name]')
  .text()
  .should.equal('Betty')
```

Results in the following error:

```
Invariant Violation: ReactDOM.render(): Invalid component element. Instead of passing a component class, make sure to instantiate it by passing it to React.createElement.
      at invariant (node_modules/fbjs/lib/invariant.js:39:15)
      at Object.ReactMount._renderSubtreeIntoContainer (node_modules/react/lib/ReactMount.js:505:89)
      at Object.ReactMount.render (node_modules/react/lib/ReactMount.js:570:23)
      at Object.wrapper [as render] (node_modules/react/lib/ReactPerf.js:66:21)
      at render (node_modules/teaspoon/utils.js:101:40)
      at QueryCollection.render (node_modules/teaspoon/element.js:110:20)
      at Context.<anonymous> (_test.js:25:19)
```

The initial fix for this (component -> element) is:

```
let Greeting = props => <div>hello <strong _testID='name'>{props.name}</strong></div>;

$(<Greeting />).render()
  .prop({ name: 'Betty' })
  .find('[_testID=name]')
  .text()
  .should.equal('Betty')
```

But this still produces the following error:

```
TypeError: (0 , _teaspoon2.default)(...).render(...).prop is not a function
      at Context.<anonymous> (_test.js:26:10)
```

I eventually guessed the following, which works:

```
let Greeting = props => <div>hello <strong _testID='name'>{props.name}</strong></div>;

$(<Greeting />)
  .props({ name: 'Betty' })
  .render()
  .find('[_testID=name]')
  .text()
  .should.equal('Betty')
```