### PR TITLE
Fix jsdom compatibiltiy for HTMLElement in Utils

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -179,7 +179,7 @@ export function getRootInstance(mountPoint){
 }
 
 export function findDOMNode(component){
-  return component instanceof HTMLElement
+  return component instanceof window.HTMLElement
     ? component
     : component && component._rootID
         ? getNode(component._rootID)


### PR DESCRIPTION
### What is the problem?

some work was done in #23 to address jsdom compatibility with teaspoon. Utils was missed so `findDOMNode` was broken in jsdom.

### How did it get fixed?

- Applied the same fix as #23 by ensuring `HTMLElement` was being pulled from `window`.
- my sublime added a newline at the end of the file, can remove if its against CS.